### PR TITLE
🚨 SECURITY: Pin axios to 0.30.3 (supply chain attack)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcodegroup-au/vue-multiselect",
       "version": "0.0.7",
       "dependencies": {
-        "axios": "^0.30.2",
+        "axios": "0.30.3",
         "underscore": "^1.13.2",
         "vue-multiselect": "^2.1.6"
       }
@@ -35,9 +35,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
-      "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
+      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.4",
@@ -328,9 +329,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
-      "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
+      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
       "requires": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "DcodeGroup",
   "license": "",
   "dependencies": {
-    "axios": "^0.30.2",
+    "axios": "0.30.3",
     "underscore": "^1.13.2",
     "vue-multiselect": "^2.1.6"
   },
@@ -24,5 +24,8 @@
   "homepage": "https://github.com/DCODE-GROUP/vue-multiselect#readme",
   "bugs": {
     "url": "https://github.com/DCODE-GROUP/vue-multiselect/issues"
+  },
+  "overrides": {
+    "axios": "0.30.3"
   }
 }


### PR DESCRIPTION
## axios supply chain attack — March 31 2026

Malicious versions `axios@1.14.1` and `axios@0.30.4` were published via compromised maintainer credentials. They inject `plain-crypto-js@4.2.1` which drops a cross-platform RAT.

### Changes
- Pins axios to `0.30.3` (last safe release)
- Adds `overrides` to block transitive resolution to compromised versions
- Regenerates lockfile

### Action required
If any machine has already installed the compromised version, treat it as compromised:
- Rotate all secrets/credentials
- Check for C2 connections to `sfrclak.com` / `142.11.206.73`
- Look for: `/Library/Caches/com.apple.act.mond` (mac), `%PROGRAMDATA%\wt.exe` (win), `/tmp/ld.py` (linux)

### References
- https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan
- https://news.ycombinator.com/item?id=47581837